### PR TITLE
Update versions in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
@@ -15,7 +15,7 @@ repos:
       # - id: no-commit-to-branch # without arguments, master/main will be protected.
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.8.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
@@ -31,12 +31,12 @@ repos:
           'pep8-naming==0.12.0'
         ]
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.0.0
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
         exclude: 'setup.py'  # Because complaining about docstrings here is annoying.
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.982
     hooks:
       - id: mypy
         args: []


### PR DESCRIPTION
Mostly necessary because the referenced version of black no longer works with the latest version of its dependencies.