### PR TITLE
Make compatible with readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,11 @@
+version: 2
+python:
+  install:
+    - requirements: requirements-readthedocs.txt
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+  jobs:
+    pre_build:
+      - cd doc && doxygen

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,10 +11,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
-from importlib.metadata import distribution
+import os
+import sys
+from importlib.metadata import PackageNotFoundError, distribution
+
+sys.path.insert(0, os.path.abspath('../src'))
 
 # -- Project information -----------------------------------------------------
 
@@ -23,10 +24,14 @@ copyright = "2022, National Research Foundation (SARAO)"
 
 # Get the information from the installed package, no need to maintain it in
 # multiple places.
-dist = distribution(project)
-
-author = dist.metadata["Author"]
-release = dist.metadata["Version"]
+try:
+    dist = distribution(project)
+except PackageNotFoundError:
+    author = "Unknown author"
+    release = "Unknown release"
+else:
+    author = dist.metadata["Author"]
+    release = dist.metadata["Version"]
 version = release
 
 # -- General configuration ---------------------------------------------------
@@ -49,6 +54,7 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
+autodoc_mock_imports = ["vkgdr._vkgdr", "pycuda"]  # Can't be built on readthedocs
 autodoc_member_order = "bysource"
 
 breathe_projects = {"vkgdr": "./doxygen/xml"}

--- a/requirements-readthedocs.txt
+++ b/requirements-readthedocs.txt
@@ -1,0 +1,3 @@
+sphinx==5.2.3
+sphinx-rtd-theme==1.0.0
+breathe==4.34.0


### PR DESCRIPTION
To make this work, the apidocs are generated from the working copy rather than the installed package (because it's not possible to install the C extension on readthedocs) and there is fallback behaviour should importlib.metadata be unable to find the version.