### PR TITLE
Fix some bit-rot

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,14 +9,22 @@ max-complexity = 15
 # specify errors/checks to ignore
 # this list is tailored to work well with the black formatter
 ignore =
-	E203, # 'whitespace before :' error
-	W503  # 'line break before binary operator' error
+        # 'whitespace before :' error
+	E203,
+	# 'line break before binary operator' error
+	W503
 
 # specify which checks to enable
 select =
-	C, # complexity checks
-	E, # pep8 errors
-	F, # pyflakes fatals
-	W, # pep8 warnings
-	B, # bugbear checks for design issues (requires flake8-bugbear)
-	N  # pep8 naming (requires pep8-naming)
+	# complexity checks
+	C,
+	# pep8 errors
+	E,
+	# pyflakes fatals
+	F,
+	# pep8 warnings
+	W,
+	# bugbear checks for design issues (requires flake8-bugbear)
+	B,
+	# pep8 naming (requires pep8-naming)
+	N

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,11 +19,11 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
     hooks:
       - id: flake8
         additional_dependencies: [

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,6 @@
 version: 2
+sphinx:
+  configuration: doc/conf.py
 python:
   install:
     - requirements: requirements-readthedocs.txt

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,7 +15,7 @@ import os
 import sys
 from importlib.metadata import PackageNotFoundError, distribution
 
-sys.path.insert(0, os.path.abspath('../src'))
+sys.path.insert(0, os.path.abspath("../src"))
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
- Update .readthedocs.yml to conform to new readthedocs requirements (https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/)
- Update URL for flake8
- Update isort to latest version (old version is uninstallable)
- Update flake8 to latest version (old version gave cryptic errors)
- Fix syntax errors in .flake8 (newer flake8 complains about end-of-line comments)