### PR TITLE
Update manylinux version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,13 +7,18 @@ jobs:
   sdist:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+        with:
+          # Need this for katversion to pick up the tags
+          # (see https://github.com/actions/checkout/issues/1471)
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.7'
       - run: pip install build==0.8.0
       - run: python -m build --sdist .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: ./dist/*.tar.gz
@@ -21,9 +26,12 @@ jobs:
   wheel:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: pypa/cibuildwheel@v2.10.2
-      - uses: actions/upload-artifact@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: pypa/cibuildwheel@v2.22.0
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./wheelhouse/*.whl

--- a/manylinux/before_all.sh
+++ b/manylinux/before_all.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
 
-yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
+yum config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
 yum -y install cuda-cudart-devel-11-6 vulkan-devel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires = [
 build-frontend = "build"
 before-all = "manylinux/before_all.sh"
 manylinux-x86_64-image = "manylinux_2_28"
-manylinux-i686-image = "manylinux_2_28"
 build = ["cp37-manylinux*"]   # Uses limited API, so only one version needed
 
 [tool.cibuildwheel.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ requires = [
 [tool.cibuildwheel]
 build-frontend = "build"
 before-all = "manylinux/before_all.sh"
-manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-i686-image = "manylinux_2_28"
 build = ["cp37-manylinux*"]   # Uses limited API, so only one version needed
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
The old manylinux2014 no longer builds because CentOS 7 is EOL. Update to manylinux_2_28.

Also update versions in the Github Actions workflow - the provided cibuildwheel was too old to work, and there were warnings about other deprecated versions of actions.