### PR TITLE
CI/packaging updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,15 @@ concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - run: pipx run pre-commit run --all-files
+
   sdist:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   sdist:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -15,8 +15,8 @@ jobs:
           fetch-tags: true
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
-      - run: pip install build==0.8.0
+          python-version: '3.9'
+      - run: pip install build==1.2.0
       - run: python -m build --sdist .
       - uses: actions/upload-artifact@v4
         with:
@@ -24,7 +24,7 @@ jobs:
           path: ./dist/*.tar.gz
 
   wheel:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
@@ -15,28 +15,28 @@ repos:
       # - id: no-commit-to-branch # without arguments, master/main will be protected.
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.1.2
     hooks:
       - id: flake8
         additional_dependencies: [
-          'flake8-bugbear==21.4.3',
-          'pep8-naming==0.12.0'
+          'flake8-bugbear==24.12.12',
+          'pep8-naming==0.14.1'
         ]
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         exclude: 'setup.py'  # Because complaining about docstrings here is annoying.
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v1.15.0
     hooks:
       - id: mypy
         args: []

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,9 @@ python:
   install:
     - requirements: requirements-readthedocs.txt
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.8"
+    python: "3.9"
   jobs:
     pre_build:
       - cd doc && doxygen

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
-python_version = 3.7
+python_version = 3.9
 ignore_missing_imports = True
 files = src/vkgdr, test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires = [
 build-frontend = "build"
 before-all = "manylinux/before_all.sh"
 manylinux-x86_64-image = "manylinux_2_28"
-build = ["cp37-manylinux*"]   # Uses limited API, so only one version needed
+build = ["cp39-manylinux*"]   # Uses limited API, so only one version needed
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ package_dir =
 packages = find:
 install_requires =
     cffi>=1.12.0
-python_requires = >=3.7
+python_requires = >=3.9
 zip_safe = false            # For py.typed
 
 [options.packages.find]
@@ -38,4 +38,4 @@ test =
     numpy
 
 [bdist_wheel]
-py_limited_api = cp37
+py_limited_api = cp39


### PR DESCRIPTION
- Use Ubuntu 24.04 instead of 20.04 for CI (the latter will be retired).
- Use Python 3.9 as the minimum version (oldest supported Python version).
- Add Github Action to run pre-commit.